### PR TITLE
Funmatch

### DIFF
--- a/R/bootstrap.R
+++ b/R/bootstrap.R
@@ -14,7 +14,7 @@ bootstrap <- function (x, ...)
 #' @description This function is used to estimating standard errors when the distribution is not know.
 #' 
 #' @param nboots The number of bootstraps.
-#' @param FUN the statistic to bootstrap, ie., mean, var, cov, etc.
+#' @param FUN the name of the statistic to bootstrap, ie., 'mean', 'var', 'cov', etc as a string.
 #' 
 #' @author Daniel Marcelino, \email{dmarcelino@@live.com}
 #' 
@@ -26,7 +26,7 @@ bootstrap <- function (x, ...)
 #' @export
 bootstrap.default<-function(x, nboots=100, FUN,  ...){
 	n=length(x)
-	lings <-replicate(nboots, FUN(sample(x, n, replace=TRUE)))
+	lings <-replicate(nboots, match.fun(FUN)(sample(x, n, replace=TRUE)))
 	list(se = sd(lings), 
        lings = lings)
 }

--- a/R/jackknife.R
+++ b/R/jackknife.R
@@ -20,19 +20,20 @@
 #' jackknife(x,'mean')
 #'
 #' @export
-`jackknife` <-function (x,p)
+jackknife <-function (x,p)
 {
-  n=length(x)
-  jk=rep(NA,n)
-
+	n=length(x)
+	jk=rep(NA,n)
+	est = match.fun(p)(x)
+	
 	for (i in 1:n)
- 	{
+	{
 		jk[i]=match.fun(p)(x[-i])
 		jkest=mean(jk)
 		jkvar=(n-1)/n*sum((jk-jkest)^2)
-		jkbias=(n-1)*(jkest-match.fun(p)(x))
-		jkbiascorr=n*match.fun(p)(x)-(n-1)*jkest
+		jkbias=(n-1)*(jkest-est)
+		jkbiascorr=n*est-(n-1)*jkest
 	}
-	list(est=match.fun(p)(x), jkest=jkest, jkvar=jkvar, jkbias=jkbias, jkbiascorr=jkbiascorr)
+	list(est=est, jkest=jkest, jkvar=jkvar, jkbias=jkbias, jkbiascorr=jkbiascorr)
 }
 NULL

--- a/R/jackknife.R
+++ b/R/jackknife.R
@@ -5,7 +5,7 @@
 #' This function is used for estimating standard errors when the distribution is not know.
 #'
 #' @param x A vector
-#' @param p An estimation of parameter
+#' @param p An function name for estimation of parameter as a string
 #'
 #' @return est orignial estimation of parameter
 #' @return jkest jackknife estimation of parameter
@@ -17,7 +17,7 @@
 #' @examples
 #' x = runif(10, 0, 1)
 #' mean(x)
-#' jackknife(x,mean)
+#' jackknife(x,'mean')
 #'
 #' @export
 `jackknife` <-function (x,p)
@@ -25,14 +25,14 @@
   n=length(x)
   jk=rep(NA,n)
 
-  for (i in 1:n)
-  {
-    jk[i]=p(x[-i])
-    jkest=mean(jk)
-    jkvar=(n-1)/n*sum((jk-jkest)^2)
-    jkbias=(n-1)*(jkest-p(x))
-    jkbiascorr=n*p(x)-(n-1)*jkest
-  }
-  list(est=p(x), jkest=jkest, jkvar=jkvar, jkbias=jkbias, jkbiascorr=jkbiascorr)
+	for (i in 1:n)
+ 	{
+		jk[i]=match.fun(p)(x[-i])
+		jkest=mean(jk)
+		jkvar=(n-1)/n*sum((jk-jkest)^2)
+		jkbias=(n-1)*(jkest-match.fun(p)(x))
+		jkbiascorr=n*match.fun(p)(x)-(n-1)*jkest
+	}
+	list(est=match.fun(p)(x), jkest=jkest, jkvar=jkvar, jkbias=jkbias, jkbiascorr=jkbiascorr)
 }
 NULL


### PR DESCRIPTION
In bootstrap and jackknife the name of a function (e.g. 'mean') is passed in, and then currently the functions attempt to call them directly from the string. However this does not work. You need to use `match.fun(FUN)`  to have the string treated as a function.  Also I made the documentation more explicity say that FUN needs to be a string (e.g. 'mean', 'var', 'cov'  not mean, var, cov).  
In `jackknife()` I also did a separate commit to only calculate `est` once which makes it run a bit faster.  